### PR TITLE
Update MiniParser.php

### DIFF
--- a/upload/library/Sedo/TinyQuattro/Helper/MiniParser.php
+++ b/upload/library/Sedo/TinyQuattro/Helper/MiniParser.php
@@ -167,6 +167,7 @@ class Sedo_TinyQuattro_Helper_MiniParser
 		}
 
 		$this->_matches = $this->_getMatchesFromSplitRegex($text);
+		reset($this->_matches);
 		$this->_tree = $this->_buildTree();
 		
 		return;
@@ -193,8 +194,9 @@ class Sedo_TinyQuattro_Helper_MiniParser
 		$nodes = array();
 		$i = 0;			
 
-		while (($value = array_shift($this->_matches)) !== NULL)
+		while (($value = current($this->_matches)) !== FALSE)
 		{
+			next($this->_matches);
 			switch ($i++ % 3)
 			{
 				case 0:


### PR DESCRIPTION
Remove the usage of array_shift when iterating over the matches array. Significant performance improvement for large tables as array_shift() is an O(N) performance compared to O(1) for current() & next()
