### PR TITLE
Respect disabled flag when returning Smilies & Fix sprite check

### DIFF
--- a/upload/library/Sedo/TinyQuattro/Helper/Smilie.php
+++ b/upload/library/Sedo/TinyQuattro/Helper/Smilie.php
@@ -138,7 +138,7 @@ class Sedo_TinyQuattro_Helper_Smilie
 				continue;
 			}
 
-			$spriteCheck = (!empty($smilie['sprite_mode'])) ? true : !empty($smilie['sprite_params']);
+			$spriteCheck = $smilie['sprite_mode'] == 1 && !empty($smilie['sprite_params']);
 			$smilieData = ($spriteCheck ? $smilie['smilie_id'] : $smilie['image_url']);
 			$smilieText = array();
 


### PR DESCRIPTION
The spirte params check is broken, and the list of Smilies doesn't respect the disabled flag.
