### PR TITLE
Fix spriteCheck logic for Xenforo 1.3

### DIFF
--- a/upload/library/Sedo/TinyQuattro/Helper/Smilie.php
+++ b/upload/library/Sedo/TinyQuattro/Helper/Smilie.php
@@ -140,7 +140,7 @@ class Sedo_TinyQuattro_Helper_Smilie
 				continue;
 			}
 
-			$spriteCheck = (!empty($smilie['sprite_mode'])) ? true : !empty($smilie['sprite_params']);
+			$spriteCheck = isset($smilie['sprite_mode']) ? $smilie['sprite_mode'] : !empty($smilie['sprite_params']);
 			$smilieData = ($spriteCheck ? $smilie['smilie_id'] : $smilie['image_url']);
 			$smilieText = array();
 


### PR DESCRIPTION
sprite_params can have stuff in it even if sprite_mode is 0, as such we do not want to collapse checking for and equals zero into the same statement with empty()
