### PR TITLE
Replace regex bbcode cleaning with bbcode DOM manipulation

### DIFF
--- a/upload/library/Sedo/TinyQuattro/BbCode/Formatter/BbCode.php
+++ b/upload/library/Sedo/TinyQuattro/BbCode/Formatter/BbCode.php
@@ -1,0 +1,14 @@
+<?php
+
+class Sedo_TinyQuattro_BbCode_Formatter_BbCode extends XenForo_BbCode_Formatter_Base
+{
+    protected function _getTagRule($tagName)
+    {
+        return false;
+    }
+
+    public function filterString($string, array $rendererStates)
+    {
+        return $string;
+    }
+}

--- a/upload/library/Sedo/TinyQuattro/ViewPublic/Editor/ToBbCode.php
+++ b/upload/library/Sedo/TinyQuattro/ViewPublic/Editor/ToBbCode.php
@@ -3,12 +3,12 @@
 class Sedo_TinyQuattro_ViewPublic_Editor_ToBbCode extends XFCP_Sedo_TinyQuattro_ViewPublic_Editor_ToBbCode
 {
 	protected $_cleanBbCodesRegex;
-	
+
 	//@extended
 	public function renderJson()
 	{
 		$parent = parent::renderJson();
-		
+
 		if(!isset($parent['bbCode']))
 		{
 			return $parent;
@@ -38,47 +38,128 @@ class Sedo_TinyQuattro_ViewPublic_Editor_ToBbCode extends XFCP_Sedo_TinyQuattro_
 			return $parent;
 		}
 
-		/*Clean BbCodes - step 1*/
-      		$guiltyTags = implode('|', array_filter(explode(',', $options->tinyquattro_guilty_tags)));
-		$this->_cleanBbCodesRegex = '#\[(?P<tag>' . $guiltyTags . ')(?P<options>=.+?)?\].+?\[/\1\](?:[\s]+\[\1(?:\2)?\].+?\[/\1\])+#iu';
-		
-		$content = $this->_cleanBbCodes($content);
+		$formatter = XenForo_BbCode_Formatter_Base::create('Sedo_TinyQuattro_BbCode_Formatter_BbCode');
+		$parser = XenForo_BbCode_Parser::create($formatter);
+		$bbcodeTree = $parser->parse($content);
 
-		/*Clean BbCodes - step 2: Fix duplicated consecutive tags: [b][b] => [b]*/
-		$content = preg_replace('#(\[(?:/)?[^\]]+\])(?:\1)+#ui', '$1', $content);
+		$guiltyTags = array_fill_keys(array_filter(explode(',', $options->tinyquattro_guilty_tags)),true);
+		$this->_cleanBbCodes($guiltyTags, null, $bbcodeTree);
 
 		/*Save and return modifications*/
-		$parent['bbCode'] = $content;
-		
+		$parent['bbCode'] = $formatter->renderTree($bbcodeTree);
+
 		return $parent;
 	}
 
-	protected function _cleanBbCodes($string)
+	protected function _cleanBbCodes(array $guiltyTags, $parentTag, &$bbcodeTree)
 	{
-		$string = preg_replace_callback($this->_cleanBbCodesRegex, array($this, '_cleanBbCodesRegexCallback'), $string);
-		return $string;
-	}
-	
-   	protected function _cleanBbCodesRegexCallback($matches)
-	{
-		$fullString = $matches[0];
-		$tag = $matches['tag'];
-		$options = (isset($matches['options'])) ? $matches['options'] : '';
-		
-		$openingTag = "[{$tag}{$options}]";
-		$closingTag = "[/$tag]";
-				
-		//Siblings BbCodes
-		$fullString = str_replace(array($openingTag, $closingTag), '', $fullString);
-		$fullString = $openingTag . $fullString . $closingTag;
-
-		//Nested BbCodes - Loop
-		if(preg_match($this->_cleanBbCodesRegex, $fullString))
+		// merge any children
+		foreach($bbcodeTree as $key => &$tag)
 		{
-			$fullString = $this->_cleanBbCodes($fullString);
-		}
+			if (isset($tag['tag']))
+			{
+				if (!isset($tag['children']))
+				{
+					$tag['children'] = array();
+				}
 
-		return $fullString;
+				$this->_cleanBbCodes($guiltyTags, $tag, $tag['children']);
+
+				$count = count($tag['children']);
+				if (count($tag['children']) == 1)
+				{
+					$childTag = reset($tag['children']);
+					if (isset($childTag['tag']) && isset($guiltyTags[$childTag['tag']]) &&
+						$childTag['tag'] == $tag['tag'] && $childTag['option'] == $tag['option'])
+					{
+						$tag['children'] = $childTag['children'];
+					}
+				}
+			}
+		}
+		// merge top-level, keep repeating untill we run out of mergable tags
+		do
+		{
+			$modified = false;
+			$lookback1Key = null;
+			$lookback1Tag = null;
+			$lookback2Key = null;
+			$lookback2Tag = null;
+			foreach($bbcodeTree as $key => &$tag)
+			{
+				if ($lookback1Tag !== null && isset($tag['tag']) && isset($guiltyTags[$tag['tag']]))
+				{
+					if (isset($tag['tag']) && $tag['tag'] == $parentTag['tag'] && $tag['option'] == $parentTag['option'])
+					{
+						// rebuild children array
+						$children = array();
+						foreach($bbcodeTree as $childkey => & $child)
+						{
+							if ($childkey == $key)
+							{
+								foreach($tag['children'] as $child)
+								{
+									$children[] = $child;
+								}
+								continue;
+							}
+							$children[] = $child;
+						}
+						$bbcodeTree = $children;
+						// remove redundant tag, restart the cleaning loop
+						$modified = true;
+						break;
+					}
+					// lookback1Tag is a string
+					if (!isset($lookback1Tag['tag']) && isset($lookback2Tag['tag']) &&
+						$tag['tag'] == $lookback2Tag['tag'] && $tag['option'] == $lookback2Tag['option'])
+					{
+						// move whitespace
+						$lastChildIndex = count($lookback2Tag['children']) - 1;
+						if ($lastChildIndex >= 0)
+						{
+							if (!isset($lookback2Tag['children'][$lastChildIndex]['tag']))
+							{
+								$lookback2Tag['children'][$lastChildIndex] .= $lookback1Tag;
+							}
+							else
+							{
+								$lookback2Tag['children'][] = $lookback1Tag;
+								$lastChildIndex += 1;
+							}
+							// merge tag
+							foreach($tag['children'] as $child)
+							{
+								if (!isset($lookback2Tag['children'][$lastChildIndex]['tag']) && !isset($child['tag']))
+								{
+									$lookback2Tag['children'][$lastChildIndex] .= $child;
+								}
+								else
+								{
+									$lookback2Tag['children'][] = $child;
+									$lastChildIndex += 1;
+								}
+							}
+						}
+						$bbcodeTree[$lookback2Key] = $lookback2Tag;
+						unset($bbcodeTree[$lookback1Key]);
+						unset($bbcodeTree[$key]);
+						$modified = true;
+						// update tracking to remove lookback1tag
+						$lookback1Key = $lookback2Key;
+						$lookback1Tag = $lookback2Tag;
+						$lookback2Key = null;
+						$lookback2Tag = null;
+						continue;
+					}
+				}
+				$lookback2Tag = $lookback1Tag;
+				$lookback2Key = $lookback1Key;
+				$lookback1Tag = $tag;
+				$lookback1Key = $key;
+			}
+		}
+		while ($modified);
 	}
 }
 //Zend_Debug::dump($class);


### PR DESCRIPTION
Uses the Standard XenForo Parser and a minor custom bbcode formatter to parser & render bbcodes.

A cleanup phase is applied to the bbcode tree which eliminates redundant bbcode before rendering.