### PR TITLE
Strikethrough fix

### DIFF
--- a/upload/library/Sedo/TinyQuattro/Helper/Editor.php
+++ b/upload/library/Sedo/TinyQuattro/Helper/Editor.php
@@ -1,7 +1,7 @@
 <?php
 class Sedo_TinyQuattro_Helper_Editor
 {
-	public static $guiltyTags = array('left','center','right','b','i','u','s','font','color','size','bcolor','justify','indent');
+	public static $guiltyTags = array('left','center','right','b','i','font','color','size','bcolor','justify','indent');
 
 	public static function tagsFixer($content)
 	{

--- a/upload/library/Sedo/TinyQuattro/Helper/MiniParser.php
+++ b/upload/library/Sedo/TinyQuattro/Helper/MiniParser.php
@@ -1050,7 +1050,7 @@ class Sedo_TinyQuattro_Helper_MiniParser
 		/*Plain Text Mode: disable*/
 		if(!empty($tagRules['plainText']) && $tagRules['plainText'] == $tagName)
 		{
-			$this->_plainText = false;
+			$this->_plainTextMode = false;
 		}
 
 		/*Plain Text Mode: disable*/


### PR DESCRIPTION
- Strike through and underline introduce changes to whitespace if they are combined, so remove them from the guilty tags list.
- plaintext variable is wrong, causing ; ```[plain][plain]test[/plain][/plain]``` to render as ```[plain]test[/plain]``` instead of ```[plain][plain]test[/plain][/plain]```.

